### PR TITLE
bugfix/status

### DIFF
--- a/app/controllers/public/comments_controller.rb
+++ b/app/controllers/public/comments_controller.rb
@@ -8,6 +8,7 @@ class Public::CommentsController < ApplicationController
     @comment.review_id = @review.id
 
     if @comment.save
+      @comments = @review.comments.active_users.includes(:user)
       render "public/comments/create.js.erb"
     else
     # 失敗した場合はエラーメッセージを表示
@@ -19,6 +20,8 @@ class Public::CommentsController < ApplicationController
     @comment = Comment.find(params[:id])
     @review = @comment.review
     @comment.destroy
+    @comments = @review.comments.active_users.includes(:user)
+      render "public/comments/destroy.js.erb"
   end
 
   private

--- a/app/controllers/public/homes_controller.rb
+++ b/app/controllers/public/homes_controller.rb
@@ -1,6 +1,9 @@
 class Public::HomesController < ApplicationController
   def top
-    @reviews = Review.includes(:user, :hut).order(created_at: :desc).limit(3)
+    @reviews = Review.active_users
+                     .includes(:user, :hut)
+                     .order(created_at: :desc)
+                     .limit(3)
   end
 
   def about

--- a/app/controllers/public/huts_controller.rb
+++ b/app/controllers/public/huts_controller.rb
@@ -5,6 +5,9 @@ class Public::HutsController < ApplicationController
 
   def show
     @hut = Hut.find(params[:id])
-    @reviews = @hut.reviews.includes(:user).order(created_at: :desc)
+    @reviews = @hut.reviews
+                   .active_users
+                   .includes(:user)
+                   .order(created_at: :desc)
   end
 end

--- a/app/controllers/public/reviews_controller.rb
+++ b/app/controllers/public/reviews_controller.rb
@@ -14,15 +14,25 @@ class Public::ReviewsController < ApplicationController
     if params[:user_id]
       # user_idのパラメーターが渡されたときは特定のユーザーのレビューを表示
       @user = User.find(params[:user_id]) 
-      @reviews = @user.reviews.includes(:hut).order(created_at: :desc).page(params[:page]).per(6)
+      @reviews = @user.reviews
+                      .includes(:hut)
+                      .active_users
+                      .order(created_at: :desc)
+                      .page(params[:page]).per(6)
     elsif params[:all_reviews]
       # すべてのレビューを表示するための条件分岐
       @user = nil
-      @reviews = Review.includes(:hut, :user).order(created_at: :desc).page(params[:page]).per(6)
+      @reviews = Review.active_users
+                       .includes(:hut, :user)
+                       .order(created_at: :desc)
+                       .page(params[:page]).per(6)
     else
       # ログイン中のユーザーのレビューを表示
       @user = current_user
-      @reviews = current_user.reviews.includes(:hut).order(created_at: :desc).page(params[:page]).per(6)
+      @reviews = current_user.reviews
+                             .includes(:hut)
+                             .order(created_at: :desc)
+                             .page(params[:page]).per(6)
     end
   end
   
@@ -31,6 +41,7 @@ class Public::ReviewsController < ApplicationController
     @review = Review.find(params[:id])
     @hut = @review.hut
     @comment = Comment.new
+    @comments = @review.comments.active_users.includes(:user)
   end
 
   def create

--- a/app/controllers/public/searches_controller.rb
+++ b/app/controllers/public/searches_controller.rb
@@ -28,7 +28,7 @@ class Public::SearchesController < ApplicationController
       end
 
     when "reviews"
-      @reviews = Review.all
+      @reviews = Review.active_users
 
       # キーワード検索
       if params[:keyword].present?

--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -47,7 +47,10 @@ class Public::UsersController < ApplicationController
   def favorites
     @user = current_user
     @favorites = @user.favorites.includes(:review)
-    @reviews = Review.joins(:favorites).where(favorites: { user_id: @user.id }).page(params[:page]).per(6)
+    @reviews = Review.active_users
+                     .joins(:favorites)
+                     .where(favorites: { user_id: @user.id })
+                     .page(params[:page]).per(6)
   end
 
   private

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -8,5 +8,7 @@ class Comment < ApplicationRecord
   has_one :notification, as: :notifiable, dependent: :destroy
 
   validates :body, presence: true, length: { maximum: 200 }
-
+  
+  #退会したuserのコメントを非表示にするための記述
+  scope :active_users, -> { joins(:user).where(users: { is_active: true }) }
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -10,6 +10,9 @@ class Review < ApplicationRecord
   validates :body, presence: true
   validates :rating, presence: true
   validate :images_limit
+
+  #退会したuserのレビューを非表示にするための記述
+  scope :active_users, -> { joins(:user).where(users: { is_active: true })}
   
 
   def favorited_by?(user)

--- a/app/views/public/comments/_index.html.erb
+++ b/app/views/public/comments/_index.html.erb
@@ -1,6 +1,6 @@
 
   <div class="mb-4">
-    <% review.comments.each do |comment| %>
+    <% @comments.each do |comment| %>
       <div class="border-bottom mb-2 pb-2">
         <div class="d-flex">
           <div class="d-flex flex-column align-items-center mr-3">

--- a/app/views/public/comments/create.js.erb
+++ b/app/views/public/comments/create.js.erb
@@ -1,2 +1,2 @@
-$("#review_comments_<%= @review.id %>").html("<%= j(render 'public/comments/index', review: @review) %>");
+$("#review_comments_<%= @review.id %>").html("<%= j(render 'public/comments/index', comments: @comments) %>");
 $("#comment_body").val("");  

--- a/app/views/public/comments/destroy.js.erb
+++ b/app/views/public/comments/destroy.js.erb
@@ -1,1 +1,1 @@
-$("#review_comments_<%= @review.id %>").html("<%= j(render "public/comments/index", review: @review) %>");
+$("#review_comments_<%= @review.id %>").html("<%= j(render "public/comments/index", comments: @comments) %>");

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -19,7 +19,7 @@
           <% if review.images.attached? %>
             <%= image_tag review.images.first, class: "card-img-top", alt: "Hut Image", style: "width: 100%; height: 200px; object-fit: cover; object-position: center;" %>
           <% else %>
-            <img src="review_no_image.jpg" class="card-img-top" alt="No Image" style="width: 100%; height: 200px; object-fit: cover; object-position: center;">
+            <%= image_tag "review_no_image.jpg", class: "card-img-top", alt: "No Image", style: "width: 100%; height: 200px; object-fit: cover; object-position: center;" %>
           <% end %>
           <div class="card-body">
             <h5 class="card-title"><%= review.hut.name %></h5>

--- a/app/views/public/reviews/show.html.erb
+++ b/app/views/public/reviews/show.html.erb
@@ -62,9 +62,9 @@
           <%= f.submit "送信する", class: "btn btn-primary mb-3" %>
         <% end %>
       
-        <h4>コメント一覧（コメント件数：<%= @review.comments.count %>）</h4>
+        <h4>コメント一覧（コメント件数：<%= @comments.count %>）</h4>
         <div id="review_comments_<%= @review.id%>">
-          <%= render "public/comments/index", review: @review %>
+          <%= render "public/comments/index", comments: @comments %>
         </div>
 
       </div>


### PR DESCRIPTION
退会後のユーザーのレビューやコメントが残っているバグを修正
・完全削除とはせず、アクティブユーザーのレビューやコメントのみ表示されるように実装
・管理者がユーザーを退会→有効にした場合には同時にレビューやコメントも復活する
・上記修正にともないコメントの非同期通信の箇所も記述変更(動作確認済)