### PR TITLE
bugfix/huts and search

### DIFF
--- a/app/controllers/admin/huts_controller.rb
+++ b/app/controllers/admin/huts_controller.rb
@@ -12,7 +12,7 @@ class Admin::HutsController < ApplicationController
   def create
     @hut = Hut.new(hut_params)
     if @hut.save
-      redirect_to admin_hut_path(@hut)
+      redirect_to admin_hut_path(@hut), notice:"山小屋を新規登録しました"
     else
       render :new
     end

--- a/app/controllers/public/searches_controller.rb
+++ b/app/controllers/public/searches_controller.rb
@@ -14,17 +14,15 @@ class Public::SearchesController < ApplicationController
       # 並び順検索
       case params[:sort]
       when 'rating_desc'
-        @huts = @huts.joins(:reviews).select("huts.*, AVG(reviews.rating) AS average_rating")
+        @huts = @huts.left_joins(:reviews) #まだratingのない山小屋も結果に表示されるようにするため
+                     .select("huts.*, COALESCE(AVG(reviews.rating), 0) AS average_rating")
                      .group("huts.id")
                      .order("average_rating DESC")
       when 'review_count_desc'
-        @huts = @huts.joins(:reviews).select("huts.*, COUNT(reviews.id) AS review_count")
+        @huts = @huts.left_joins(:reviews) #まだレビューのない山小屋も結果に表示されるようにするため
+                     .select("huts.*, COALESCE(COUNT(reviews.id), 0) AS review_count")
                      .group("huts.id")
                      .order("review_count DESC")
-      when 'newest'
-        @huts = @huts.joins(:reviews).select("huts.*, MAX(reviews.created_at) AS latest_review")
-                     .group("huts.id")
-                     .order("latest_review DESC")
       end
 
     when "reviews"


### PR DESCRIPTION
レビューがまだ投稿されていない山小屋が検索結果に表示されないバグを修正
・山小屋を探す＋キーワード検索＋評価の高い順orレビューの多い順で検索した際に、レビューがまだ書かれておらず評価０のものが検索結果に表示されなかったため、0のものも含めて表示されるように修正。